### PR TITLE
Create topic analysis code template

### DIFF
--- a/backend_api/ESG_Keywords.txt
+++ b/backend_api/ESG_Keywords.txt
@@ -1,0 +1,126 @@
+## Basic ##
+Environment
+Emissions
+Resource Use
+Innovation
+Social
+Human Rights
+Product Responsibility
+Workforce
+Community
+Governance
+Management
+Shareholders
+CSR Strategy
+## Extended ##
+Racial Justice
+Disability
+LGBT+ Inclusion
+Vulnerable Communities Worker Safety
+Refugees
+Inequality
+Human Trafficking
+Access In-Work Poverty
+Conflict Minerals
+Forced Labor
+Migration Child Labor
+Education
+Human Rights
+Freedom of Assembly
+Skills
+Alcohol Abuse
+Just Transition
+Healthcare
+Access to Justice
+Drug Pricing
+Gambling
+Labor Relations
+AI / Automation
+Future of Work
+Health
+Addiction
+Fake News
+Anti-microbial Resistance
+Mental Health
+Food Safety
+Disinformation
+Pandemics
+Burnout
+Sugar
+Food Substance Misuse
+Workplace health Nutrition Hunger
+Living Wage Digital Inclusion
+Financial Inclusion
+Working Conditions
+Gender Equality
+Diversity
+Waste
+Climate Change
+Biodiversity
+Water
+Resource Use
+Recycling
+Ecotoxicity
+Ocean Plastic
+Food Waste
+Circular Economy
+Rare Earths
+Pollution
+Extraction Desertification
+Water Scarcity Air Quality
+Soil
+Drinkable Water
+Soil Acidification
+Crop Yields
+Pesticides
+Regenerative Agriculture
+Fertilizers
+Clean Energy
+Bee Fertility
+Net Zero
+Climate Adaptation
+Floods
+Carbon Emissions
+Conservation
+Animal Welfare
+Mass Extinction
+Ecosystem Collapse
+Over-fishing
+Deforestation
+Sea-Level Rises
+Ocean Acidification
+Topsoil Loss
+Discrimination
+Conduct
+Board
+Remuneration
+Data
+Tax
+Homophobia
+Money Laundering
+Corruption
+Transparency
+Sexism
+Workplace Conduct
+Financial Crime
+Racism
+Inappropriate Behavior
+Bullying
+Anti-trust Mis-selling
+Harassment
+Transphobia
+Rate Fixing
+Oversight
+Bribery
+Fraud
+Composition
+Criminal Misconduct
+Data Misuse
+Capacity and Competency
+Privacy
+Corporate Tax
+Data Stewardship
+Tax Avoidance
+Bonuses Dividends
+Share Buybacks
+CEO Pay

--- a/backend_api/README.md
+++ b/backend_api/README.md
@@ -144,3 +144,7 @@ If you get an error on Windows similar to this: `running scripts is disabled on 
 
 ## Get Started Coding!
 Alright, now it's your time to start coding. Take a look at the main.py to see how it works, and how you should improve it!
+
+For those curious about Data Science, jupyter notebooks (.ipynb or iPython Notebook files) are an essential part of experimentation. You can test out different AI/ML models on different data much quicker using them, compared to using regular .py files. Feel free to experiment with different methods of topic analysis in TopicAnalyser.ipynb, or try using different data. 
+When you're finished experimenting, consider making your experimented code available in TopicAnalyser.py, and make TopicAnalyser.py part of your API in main.py.
+(NOTE: this is only one optional path you can take with your project)

--- a/backend_api/TopicAnalyser.ipynb
+++ b/backend_api/TopicAnalyser.ipynb
@@ -1,0 +1,256 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "033bbd33",
+   "metadata": {},
+   "source": [
+    "# TopicAnalyser"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91b5ba13",
+   "metadata": {},
+   "source": [
+    "For those curious about Data Science, jupyter notebooks are an essential part of experimentation. You can quickly test out different AI/ML models on different data. Feel free to experiment with different methods of topic analysis here, or try with different data here. Consider making your experimented code available in TopicAnalyser.py, and part of your API in main.py."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "53aaef96",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-03-18T15:03:26.876663Z",
+     "start_time": "2022-03-18T15:03:07.219870Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/stewart/miniconda3/envs/fizzbuzz/lib/python3.10/site-packages/sklearn/utils/deprecation.py:87: FutureWarning: Function get_feature_names is deprecated; get_feature_names is deprecated in 1.0 and will be removed in 1.2. Please use get_feature_names_out instead.\n",
+      "  warnings.warn(msg, category=FutureWarning)\n",
+      "/Users/stewart/miniconda3/envs/fizzbuzz/lib/python3.10/site-packages/sklearn/decomposition/_nmf.py:1422: FutureWarning: `alpha` was deprecated in version 1.0 and will be removed in 1.2. Use `alpha_W` and `alpha_H` instead\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Topic 0:\n",
+      "people time right did good said say make way government\n",
+      "Topic 1:\n",
+      "window problem using server application screen display motif manager running\n",
+      "Topic 2:\n",
+      "god jesus bible christ faith believe christian christians sin church\n",
+      "Topic 3:\n",
+      "game team year games season players play hockey win league\n",
+      "Topic 4:\n",
+      "new 00 sale 10 price offer shipping condition 20 15\n",
+      "Topic 5:\n",
+      "thanks mail advance hi looking info help information address appreciated\n",
+      "Topic 6:\n",
+      "windows file files dos program version ftp ms directory running\n",
+      "Topic 7:\n",
+      "edu soon cs university ftp internet article email pub david\n",
+      "Topic 8:\n",
+      "key chip clipper encryption keys escrow government public algorithm nsa\n",
+      "Topic 9:\n",
+      "drive scsi drives hard disk ide floppy controller cd mac\n",
+      "Topic 10:\n",
+      "just ll thought tell oh little fine work wanted mean\n",
+      "Topic 11:\n",
+      "does know anybody mean work say doesn help exist program\n",
+      "Topic 12:\n",
+      "card video monitor cards drivers bus vga driver color memory\n",
+      "Topic 13:\n",
+      "like sounds looks look bike sound lot things really thing\n",
+      "Topic 14:\n",
+      "don know want let need doesn little sure sorry things\n",
+      "Topic 15:\n",
+      "car cars engine speed good bike driver road insurance fast\n",
+      "Topic 16:\n",
+      "ve got seen heard tried good recently times try couple\n",
+      "Topic 17:\n",
+      "use used using work available want software need image data\n",
+      "Topic 18:\n",
+      "think don lot try makes really pretty wasn bit david\n",
+      "Topic 19:\n",
+      "com list dave internet article sun hp email ibm phone\n",
+      "Topic 0:\n",
+      "people gun state control right guns crime states law police\n",
+      "Topic 1:\n",
+      "time question book years did like don space answer just\n",
+      "Topic 2:\n",
+      "mr line rules science stephanopoulos title current define int yes\n",
+      "Topic 3:\n",
+      "key chip keys clipper encryption number des algorithm use bit\n",
+      "Topic 4:\n",
+      "edu com cs vs w7 cx mail uk 17 send\n",
+      "Topic 5:\n",
+      "use does window problem way used point different case value\n",
+      "Topic 6:\n",
+      "windows thanks know help db does dos problem like using\n",
+      "Topic 7:\n",
+      "bike water effect road design media dod paper like turn\n",
+      "Topic 8:\n",
+      "don just like think know people good ve going say\n",
+      "Topic 9:\n",
+      "car new price good power used air sale offer ground\n",
+      "Topic 10:\n",
+      "file available program edu ftp information files use image version\n",
+      "Topic 11:\n",
+      "ax max b8f g9v a86 145 pl 1d9 0t 34u\n",
+      "Topic 12:\n",
+      "government law privacy security legal encryption court fbi technology information\n",
+      "Topic 13:\n",
+      "card bit memory output video color data mode monitor 16\n",
+      "Topic 14:\n",
+      "drive scsi disk mac hard apple drives controller software port\n",
+      "Topic 15:\n",
+      "god jesus people believe christian bible say does life church\n",
+      "Topic 16:\n",
+      "year game team games season play hockey players league player\n",
+      "Topic 17:\n",
+      "10 00 15 25 20 11 12 14 16 13\n",
+      "Topic 18:\n",
+      "armenian israel armenians war people jews turkish israeli said women\n",
+      "Topic 19:\n",
+      "president people new said health year university school day work\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn.feature_extraction.text import TfidfVectorizer, CountVectorizer\n",
+    "from sklearn.datasets import fetch_20newsgroups\n",
+    "from sklearn.decomposition import NMF, LatentDirichletAllocation\n",
+    "\n",
+    "def display_topics(model, feature_names, no_top_words):\n",
+    "    for topic_idx, topic in enumerate(model.components_):\n",
+    "        print(\"Topic %d:\" % (topic_idx))\n",
+    "        print(\" \".join([feature_names[i]\n",
+    "                        for i in topic.argsort()[:-no_top_words - 1:-1]]))\n",
+    "\n",
+    "dataset = fetch_20newsgroups(shuffle=True, random_state=1, remove=('headers', 'footers', 'quotes'))\n",
+    "documents = dataset.data\n",
+    "\n",
+    "no_features = 1000\n",
+    "\n",
+    "# NMF is able to use tf-idf\n",
+    "tfidf_vectorizer = TfidfVectorizer(max_df=0.95, min_df=2, max_features=no_features, stop_words='english')\n",
+    "tfidf = tfidf_vectorizer.fit_transform(documents)\n",
+    "tfidf_feature_names = tfidf_vectorizer.get_feature_names()\n",
+    "\n",
+    "# LDA can only use raw term counts for LDA because it is a probabilistic graphical model\n",
+    "tf_vectorizer = CountVectorizer(max_df=0.95, min_df=2, max_features=no_features, stop_words='english')\n",
+    "tf = tf_vectorizer.fit_transform(documents)\n",
+    "tf_feature_names = tf_vectorizer.get_feature_names()\n",
+    "\n",
+    "no_topics = 20\n",
+    "\n",
+    "# Run NMF\n",
+    "nmf = NMF(n_components=no_topics, random_state=1, alpha=.1, l1_ratio=.5, init='nndsvd').fit(tfidf)\n",
+    "\n",
+    "# Run LDA\n",
+    "lda = LatentDirichletAllocation(n_components=no_topics, max_iter=5, learning_method='online', learning_offset=50.,random_state=0).fit(tf)\n",
+    "\n",
+    "no_top_words = 10\n",
+    "display_topics(nmf, tfidf_feature_names, no_top_words)\n",
+    "display_topics(lda, tf_feature_names, no_top_words)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f05ac2fd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.2"
+  },
+  "latex_envs": {
+   "LaTeX_envs_menu_present": true,
+   "autoclose": false,
+   "autocomplete": true,
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 1,
+   "hotkeys": {
+    "equation": "Ctrl-E",
+    "itemize": "Ctrl-I"
+   },
+   "labels_anchors": false,
+   "latex_user_defs": false,
+   "report_style_numbering": false,
+   "user_envs_cfg": false
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/backend_api/TopicAnalyser.py
+++ b/backend_api/TopicAnalyser.py
@@ -1,0 +1,49 @@
+import logging
+
+from sklearn.feature_extraction.text import TfidfVectorizer, CountVectorizer
+from sklearn.datasets import fetch_20newsgroups
+from sklearn.decomposition import NMF, LatentDirichletAllocation
+
+class TopicAnalyser:
+    def __init__(self, model_type = "nmf", data = None):
+        self.model_type = model_type
+        self.data = data
+
+    # get the topic analysis of the whole text
+    def display_topics(model, feature_names, no_top_words):
+        for topic_idx, topic in enumerate(model.components_):
+            return " ".join([feature_names[i] for i in topic.argsort()[:-no_top_words - 1:-1]])
+
+    def analyse(self):
+        # TODO: participants should consider changing dataset to match the brief.
+        if (self.data == None):
+            dataset = fetch_20newsgroups(shuffle=True, random_state=1, remove=('headers', 'footers', 'quotes'))
+            documents = dataset.data
+
+        # HYPERPARAMETERS: Consider tuning
+        no_features = 1000
+        no_topics = 20
+
+        if self.model_type == "nmf":
+            # NMF is able to use tf-idf
+            tfidf_vectorizer = TfidfVectorizer(max_df=0.95, min_df=2, max_features=no_features, stop_words='english')
+            tfidf = tfidf_vectorizer.fit_transform(documents)
+            tfidf_feature_names = tfidf_vectorizer.get_feature_names()
+            # Run NMF
+            model = NMF(n_components=no_topics, random_state=1, alpha=.1, l1_ratio=.5, init='nndsvd').fit(tfidf)
+        elif self.model_type == "lda":
+            # LDA can only use raw term counts for LDA because it is a probabilistic graphical model
+            tf_vectorizer = CountVectorizer(max_df=0.95, min_df=2, max_features=no_features, stop_words='english')
+            tf = tf_vectorizer.fit_transform(documents)
+            tf_feature_names = tf_vectorizer.get_feature_names()
+            # Run LDA
+            model = LatentDirichletAllocation(n_components=no_topics, max_iter=5, learning_method='online',
+                                        learning_offset=50., random_state=0).fit(tf)
+        else:
+            logging.exception("Invalid model_type: {}".format(self.model_type))
+
+        # HYPERPARAMETER: Consider tuning
+        no_top_words = 10
+
+        topics = self.display_topics(model, tfidf_feature_names, no_top_words)
+        return topics

--- a/backend_api/requirements.txt
+++ b/backend_api/requirements.txt
@@ -4,3 +4,4 @@ gunicorn==19.10.0; python_version < '3.0'
 google-cloud-datastore==2.1.0
 google-cloud-language==2.0.0
 flask-restx==0.5.1
+scikit-learn==1.0.2


### PR DESCRIPTION
Adding some code, but not added to the main.py api itself, leaving that up to participants. Left some documentation about how to take experiments from TopicAnalyser.ipynb, add to the class TopicAnalyser in TopicAnalyser.py, and a prompt to then consider how to add to the api itself