### PR TITLE
Update AppEngine dependencies for Python 3.7

### DIFF
--- a/backend_api/app.yaml
+++ b/backend_api/app.yaml
@@ -3,7 +3,7 @@ env: flex
 entrypoint: gunicorn -b :$PORT main:app
 
 runtime_config:
-  python_version: 3
+  python_version: 3.7
 
 automatic_scaling:
   max_num_instances: 5

--- a/backend_api/requirements.txt
+++ b/backend_api/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.2
+Flask==2.0.3
 gunicorn==20.0.4; python_version > '3.0'
 gunicorn==19.10.0; python_version < '3.0'
 google-cloud-datastore==2.1.0


### PR DESCRIPTION
scikit-learn 1.0.2 requires Python>=3.7
therefore app.yml runtime_config must specify Python 3.7
Flask 1.1.2 fails with
  "ImportError: cannot import name 'json' from 'itsdangerous'"